### PR TITLE
Add realtime mindmap hook

### DIFF
--- a/src/hooks/useMindmap.ts
+++ b/src/hooks/useMindmap.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import type { MindmapStructure } from '@/components/mindmap/MindmapVisualization';
+
+export const useMindmap = (mindmapId?: string | null, initial?: MindmapStructure | null) => {
+  const [mindmap, setMindmap] = useState<MindmapStructure | null>(initial ?? null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!mindmapId) return;
+
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+
+    const fetchMindmap = async () => {
+      const { data, error } = await supabase
+        .from('mindmaps')
+        .select('data')
+        .eq('id', mindmapId)
+        .single();
+
+      if (!error && data) {
+        setMindmap(data.data as MindmapStructure);
+      }
+      setLoading(false);
+    };
+
+    fetchMindmap();
+
+    channel = supabase
+      .channel(`mindmaps-${mindmapId}`)
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'mindmaps', filter: `id=eq.${mindmapId}` },
+        payload => {
+          const newMap = payload.new?.data as MindmapStructure | undefined;
+          if (newMap) setMindmap(newMap);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      if (channel) supabase.removeChannel(channel);
+    };
+  }, [mindmapId]);
+
+  return { mindmap, loading };
+};

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -482,7 +482,7 @@ const ProjectDetail = () => {
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500" />
                   </div>
                 ) : mindmap ? (
-                  <MindmapVisualization mindmap={mindmap} onNodeClick={handleNodeClick} width={800} height={600} />
+                  <MindmapVisualization mindmap={mindmap} mindmapId={mindmapId || undefined} onNodeClick={handleNodeClick} width={800} height={600} />
                 ) : (
                   <div className="border-2 border-dashed border-gray-200 rounded-lg p-12 text-center">
                     <Activity className="h-12 w-12 text-gray-400 mx-auto mb-4" />


### PR DESCRIPTION
## Summary
- implement `useMindmap` hook using Supabase realtime
- integrate hook in `MindmapVisualization`
- pass `mindmapId` from `ProjectDetail`

## Testing
- `npm run lint` *(fails: 45 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684f4d0d132c8327b3b517608f55ca0f